### PR TITLE
Add background selector and simplify gallery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+background/*
+!background/.gitkeep

--- a/assets/css/editor.css
+++ b/assets/css/editor.css
@@ -1,0 +1,21 @@
+.fd-backgrounds-block {
+  margin-top: 10px;
+}
+.fd-backgrounds-block h4 {
+  margin: 0 0 5px;
+}
+.fd-backgrounds-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+.fd-background-thumb {
+  width: 100px;
+  height: 60px;
+  background-size: cover;
+  background-position: center;
+  cursor: pointer;
+}
+.fd-background-thumb:hover {
+  border: 2px solid #0073aa;
+}

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -1,4 +1,22 @@
 jQuery(function($) {
+  function insertBackgroundSelector() {
+    if (!Array.isArray(fd_ajax.backgrounds) || !fd_ajax.backgrounds.length) return;
+    var $wrapper = $('#config-wrapper .uploaded-imgs-wrapper');
+    if (!$wrapper.length) return;
+
+    var $block = $('<div class="fd-backgrounds-block"><h4>Backgrounds</h4><div class="fd-backgrounds-list"></div></div>');
+    fd_ajax.backgrounds.forEach(function(url) {
+      var $thumb = $('<div class="fd-background-thumb"></div>').css('background-image', 'url(' + url + ')');
+      $thumb.on('click', function() {
+        var loc = new URL(window.location.href);
+        loc.searchParams.set('image', url);
+        window.location.href = loc.toString();
+      });
+      $block.find('.fd-backgrounds-list').append($thumb);
+    });
+    $wrapper.after($block);
+  }
+
   $('#open-designer').on('click', function() {
     const popup = window.open(
       fd_ajax.popup_url + '?image=' + encodeURIComponent(fd_ajax.image_url),
@@ -18,4 +36,6 @@ jQuery(function($) {
 
     window.addEventListener('message', listener);
   });
+
+  insertBackgroundSelector();
 });

--- a/filerobot-designer.php
+++ b/filerobot-designer.php
@@ -85,6 +85,19 @@ function fd_get_clipart_gallery() {
     return $gallery;
 }
 
+/**
+ * Return list of background image URLs.
+ */
+function fd_get_background_images() {
+    $dir = FD_PLUGIN_PATH . 'background';
+    $url = plugins_url('background', __FILE__);
+    $urls = [];
+    foreach (fd_list_files($dir) as $file) {
+        $urls[] = trailingslashit($url) . basename($file);
+    }
+    return $urls;
+}
+
 
 // Add product setting to enable the designer
 add_action('woocommerce_product_options_general_product_data', function() {
@@ -108,14 +121,17 @@ add_action('wp_enqueue_scripts', function() {
     if (is_product()) {
         $enabled = get_post_meta(get_the_ID(), '_fd_enable_designer', true);
         if ($enabled === 'yes') {
-            $image_url = esc_url(get_the_post_thumbnail_url(get_the_ID(), 'full'));
+            $param = isset($_GET['image']) ? esc_url_raw(wp_unslash($_GET['image'])) : '';
+            $image_url = $param ? $param : esc_url(get_the_post_thumbnail_url(get_the_ID(), 'full'));
+            wp_enqueue_style('fd-editor', FD_PLUGIN_URL . 'assets/css/editor.css', [], FD_VERSION);
             wp_enqueue_script('fd-editor', FD_PLUGIN_URL . 'assets/js/editor.js', ['jquery'], FD_VERSION, true);
             wp_localize_script('fd-editor', 'fd_ajax', [
-                'ajax_url'  => admin_url('admin-ajax.php'),
-                'nonce'     => wp_create_nonce('fd_nonce'),
-                'image_url' => $image_url,
-                'popup_url' => esc_url(FD_PLUGIN_URL . 'popup/index.html'),
-                'gallery'   => fd_get_clipart_gallery(),
+                'ajax_url'   => admin_url('admin-ajax.php'),
+                'nonce'      => wp_create_nonce('fd_nonce'),
+                'image_url'  => $image_url,
+                'popup_url'  => esc_url(FD_PLUGIN_URL . 'popup/index.html'),
+                'gallery'    => fd_get_clipart_gallery(),
+                'backgrounds'=> fd_get_background_images(),
             ]);
         }
     }

--- a/popup/index.html
+++ b/popup/index.html
@@ -17,39 +17,27 @@
     const params = new URLSearchParams(location.search);
     const imageUrl = params.get('image');
 
-    const categories = window.opener?.fd_ajax?.gallery || {};
-    const categoryNames = Object.keys(categories);
-
-    function getCategoryPreview(name) {
-      const imgs = categories[name] || [];
-      const previewItem = imgs.find(img => /category-preview\.(jpg|png|webp)$/i.test(img.url));
-      const target = previewItem || imgs[0];
-      return target ? (target.preview || target.url) : '';
-    }
-
-
-    function buildGallery(name) {
-      return (categories[name] || [])
-        .filter(img => !/category-preview\.(jpg|png|webp)$/i.test(img.url))
-        .map(img => ({
-          originalUrl: img.url,
-          previewUrl: img.preview || img.url
-        }));
-    }
+    const galleryObj = window.opener?.fd_ajax?.gallery || {};
+    const gallery = Object.values(galleryObj)
+      .flat()
+      .filter(img => !/category-preview\.(jpg|png|webp)$/i.test(img.url))
+      .map(img => ({
+        originalUrl: img.url,
+        previewUrl: img.preview || img.url
+      }));
 
     const { TABS, TOOLS } = window.FilerobotImageEditor;
     const editor = new window.FilerobotImageEditor(document.getElementById('editor_container'), {});
 
-    function renderWithCategory(name) {
-      const gal = buildGallery(name);
+    function renderEditor() {
       editor.render({
         source: imageUrl || 'https://scaleflex.airstore.io/demo/stephen-walker-unsplash.jpg',
         toolsIds: ['Watermark', 'Image'],
         tabsIds: [TABS.ANNOTATE, TABS.WATERMARK],
         defaultTabId: TABS.ANNOTATE,
         defaultToolId: TOOLS.IMAGE,
-        Image: { gallery: gal },
-        Watermark: { gallery: gal.map(g => ({ url: g.originalUrl, preview: g.previewUrl })) },
+        Image: { gallery: gallery },
+        Watermark: { gallery: gallery.map(g => ({ url: g.originalUrl, preview: g.previewUrl })) },
         onSave: (imageData) => {
           fetch(window.opener.fd_ajax.ajax_url, {
             method: 'POST',
@@ -76,57 +64,7 @@
       });
     }
 
-    function buildCategoryButtons(container) {
-      container.innerHTML = '';
-      categoryNames.forEach(name => {
-        const btn = document.createElement('button');
-        btn.type = 'button';
-        btn.dataset.category = name;
-        const previewUrl = getCategoryPreview(name);
-        if (previewUrl) {
-          const img = document.createElement('img');
-          img.src = previewUrl;
-          img.alt = name;
-          img.style.maxWidth = '40px';
-          img.style.maxHeight = '40px';
-          btn.appendChild(img);
-        }
-        const span = document.createElement('span');
-        span.textContent = name;
-        btn.appendChild(span);
-        btn.addEventListener('click', (e) => {
-          e.stopPropagation();
-          renderWithCategory(name);
-        });
-        container.appendChild(btn);
-      });
-    }
-
-    const menuObserver = new MutationObserver(mutations => {
-      mutations.forEach(mutation => {
-        mutation.addedNodes.forEach(node => {
-          if (node.nodeType === 1 && node.classList.contains('SfxMenu-root')) {
-            const menu = node.querySelector('.FIE_image-tool-add-option-menu');
-            if (menu) {
-              let holder = menu.querySelector('.fd-popup-category-picker');
-              if (!holder) {
-                holder = document.createElement('div');
-                holder.className = 'fd-popup-category-picker';
-                holder.style.display = 'flex';
-                holder.style.gap = '5px';
-                holder.style.flexWrap = 'wrap';
-                holder.style.padding = '8px';
-                menu.appendChild(holder);
-              }
-              buildCategoryButtons(holder);
-            }
-          }
-        });
-      });
-    });
-    menuObserver.observe(document.body, { childList: true, subtree: true });
-
-    renderWithCategory(categoryNames[0] || '');
+    renderEditor();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ignore `background/` images in repo
- expose background images via `fd_get_background_images`
- reload selected background using new JS/CSS block
- simplify popup gallery by removing categories

## Testing
- `php -l filerobot-designer.php`
- `node --check assets/js/editor.js`


------
https://chatgpt.com/codex/tasks/task_e_687d53d3fa2c832a830032a4dea6d8b9